### PR TITLE
adding instructions for installing as an Ember addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ See the ***0.x*** branch for 0.x code and fixes.
 
 `npm install ember-cli-toggle`
 
+### Install as an Ember addon
+
+`ember install ember-cli-toggle`
+
 ## Basic Usage
 
 ````hbs

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ See the ***0.x*** branch for 0.x code and fixes.
 
 ## Install
 
-`npm install ember-cli-toggle`
-
-### Install as an Ember addon
-
 `ember install ember-cli-toggle`
 
 ## Basic Usage


### PR DESCRIPTION
I'm not yet familiar enough with the Ember ecosystem to know if the npm install instructions are outdated or still valid so I left in place.  Great project -- thanks for sharing your work.